### PR TITLE
Fixing wrong status code error

### DIFF
--- a/index.js
+++ b/index.js
@@ -101,5 +101,9 @@ function isResponseIncompleted(response) {
 }
 
 function setAlexaSessionId(sessionId) {
-    alexaSessionId = sessionId.split('amzn1.echo-api.session.').pop();
+    if (sessionId.indexOf("amzn1.echo-api.session.") != -1) {
+        alexaSessionId = sessionId.split('amzn1.echo-api.session.').pop();
+    } else {
+        alexaSessionId = sessionId.split('SessionId.').pop();
+    }
 }


### PR DESCRIPTION
I've fixed the common "wrong status code error" that has been popping up.

There are two different types of session ids — one that seems to get sent during tests on the Alexa Service Simulator and another that gets sent from actual Amazon Echo devices. So I've got a check that ensures both of these work.

Thank you @Gnzlt for your great work on getting this one started, working off this as a base has been the only way I've been able to connect up Api.ai to Alexa successfully :) Will be teaching others how to do this and plan on directing them to the Alexa Api.ai Bridge!

PatCat