### PR TITLE
Added Handling of AMAZON.HelpIntent

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,11 @@ Bridge to connect Amazon Alexa to Api.ai using an AWS Lambda Function.
 * Create a new Intent called **Default Bye Event**:
 	* Add **`BYE`** as a trigger Event.
 	* Add or modify any text responses which will be triggered as a goodbye response.
+	* Ensure that all contexts are deleted when this event is triggered.
+
+* Create a new Intent called **Default Help Event**:
+	* Add **`HELP`** as a trigger Event.
+	* Add or modify any text responses which will be triggered when the user asks for help.
 
 #### Agent Settings
 * Select the gear icon (upper-left corner) and go to **Settings**.

--- a/index.js
+++ b/index.js
@@ -58,7 +58,16 @@ var handlers = {
         this.emit('AMAZON.StopIntent');
     },
     'AMAZON.HelpIntent': function () {
-        this.emit('Unhandled');
+        var self = this;
+        ApiAi.eventRequest({name: 'HELP'}, {sessionId: alexaSessionId})
+            .on('response', function (response) {
+                self.emit(':ask', response.result.fulfillment.speech);
+            })
+            .on('error', function (error) {
+                console.error(error.message);
+                self.emit(':tell', error.message);
+            })
+            .end();
     },
     'AMAZON.StopIntent': function () {
         var self = this;

--- a/index.js
+++ b/index.js
@@ -61,7 +61,8 @@ var handlers = {
         var self = this;
         ApiAi.eventRequest({name: 'HELP'}, {sessionId: alexaSessionId})
             .on('response', function (response) {
-                self.emit(':ask', response.result.fulfillment.speech);
+                var speech = response.result.fulfillment.speech;
+                self.emit(':ask', speech, speech);
             })
             .on('error', function (error) {
                 console.error(error.message);


### PR DESCRIPTION
Amazon requires that the skill implements AMAZON.HelpIntent to pass certification. I added in basic handling of the event. I also updated the readme to explain how to setup the intent in api.ai.

Also added a clarification to the readme for AMAZON.StopIntent. In order for the session to be ended, all contexts need to be deleted (that is how the function isResponseIncompleted checks if the session is over).